### PR TITLE
fix issue/2: if overlay isn't found error in console

### DIFF
--- a/source/loading-overlay.directive.js
+++ b/source/loading-overlay.directive.js
@@ -54,6 +54,10 @@
       }
 
       function updateOverlayElement(referenceId) {
+        if (overlayElement === undefined) {
+          return false;
+        }
+        
         if (bsLoadingOverlayService.isActive(referenceId)) {
           if (!overlayElement.isAttached) {
             addOverlay();


### PR DESCRIPTION
fix https://github.com/bsalex/angular-loading-overlay/issues/2
