### PR TITLE
Update build script to include .d.ts files in dist

### DIFF
--- a/dist/BsLoadingOverlayDirective.d.ts
+++ b/dist/BsLoadingOverlayDirective.d.ts
@@ -1,0 +1,14 @@
+import { BsLoadingOverlayService } from './BsLoadingOverlayService';
+export default class BsLoadingOverlayDirective implements ng.IDirective {
+    private $compile;
+    private $rootScope;
+    private $templateRequest;
+    private $q;
+    private $timeout;
+    private bsLoadingOverlayService;
+    constructor($compile: ng.ICompileService, $rootScope: ng.IRootScopeService, $templateRequest: ng.ITemplateRequestService, $q: ng.IQService, $timeout: ng.ITimeoutService, bsLoadingOverlayService: BsLoadingOverlayService);
+    private updateOverlayElement(overlayInstance);
+    restrict: string;
+    link: ng.IDirectiveLinkFn;
+}
+export declare const BsLoadingOverlayDirectiveFactory: ng.IDirectiveFactory;

--- a/dist/BsLoadingOverlayDirective.spec.d.ts
+++ b/dist/BsLoadingOverlayDirective.spec.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../typings/index.d.ts" />

--- a/dist/BsLoadingOverlayInstance.d.ts
+++ b/dist/BsLoadingOverlayInstance.d.ts
@@ -1,0 +1,14 @@
+export default class BsLoadingOverlayInstance {
+    referenceId: string;
+    delay: number;
+    activeClass: string;
+    $element: ng.IAugmentedJQuery;
+    overlayElement: ng.IAugmentedJQuery;
+    private $timeout;
+    private $q;
+    private delayPromise;
+    constructor(referenceId: string, delay: number, activeClass: string, $element: ng.IAugmentedJQuery, overlayElement: ng.IAugmentedJQuery, $timeout: any, $q: any);
+    private isAdded();
+    add(): void;
+    remove(): void;
+}

--- a/dist/BsLoadingOverlayModule.d.ts
+++ b/dist/BsLoadingOverlayModule.d.ts
@@ -1,0 +1,2 @@
+declare var _default: ng.IModule;
+export default _default;

--- a/dist/BsLoadingOverlayService.d.ts
+++ b/dist/BsLoadingOverlayService.d.ts
@@ -1,0 +1,21 @@
+import IBsLoadingOverlayOptions from './IBsLoadingOverlayOptions';
+import IBsLoadingOverlayHandler from './IBsLoadingOverlayHandler';
+export declare class BsLoadingOverlayService {
+    private $rootScope;
+    private $q;
+    constructor($rootScope: ng.IRootScopeService, $q: ng.IQService);
+    globalConfig: IBsLoadingOverlayOptions;
+    activeOverlays: {
+        [key: string]: boolean;
+    };
+    start(options?: IBsLoadingOverlayOptions): void;
+    wrap(options: IBsLoadingOverlayOptions, promiseFunction: ng.IPromise<any> | (() => (ng.IPromise<any> | {}))): ng.IPromise<any>;
+    createHandler: (options: IBsLoadingOverlayOptions) => IBsLoadingOverlayHandler;
+    notifyOverlays(referenceId: string): void;
+    stop(options?: IBsLoadingOverlayOptions): void;
+    isActive: (referenceId?: string) => boolean;
+    setGlobalConfig: (options: IBsLoadingOverlayOptions) => any;
+    getGlobalConfig: () => IBsLoadingOverlayOptions;
+}
+declare const bsLoadingOverlayServiceFactory: ($rootScope: ng.IRootScopeService, $q: ng.IQService) => BsLoadingOverlayService;
+export default bsLoadingOverlayServiceFactory;

--- a/dist/IBsLoadingOverlayHandler.d.ts
+++ b/dist/IBsLoadingOverlayHandler.d.ts
@@ -1,0 +1,6 @@
+interface IBsLoadingOverlayHandler {
+    start: () => void;
+    stop: () => void;
+    wrap: (promiseFunction: ng.IPromise<any> | (() => (ng.IPromise<any> | {}))) => ng.IPromise<any>;
+}
+export default IBsLoadingOverlayHandler;

--- a/dist/IBsLoadingOverlayOptions.d.ts
+++ b/dist/IBsLoadingOverlayOptions.d.ts
@@ -1,0 +1,8 @@
+interface IBsLoadingOverlayOptions {
+    referenceId?: string;
+    templateUrl?: string;
+    templateOptions?: any;
+    activeClass?: string;
+    delay?: number;
+}
+export default IBsLoadingOverlayOptions;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "karma start --single-run",
     "prepush": "npm test && npm run build && git add -u && git diff-index --quiet HEAD || git commit -q -m 'Build'",
     "watch": "webpack-dev-server --host 0.0.0.0",
-    "build": "webpack",
+    "build": "webpack && mv source/*.d.ts dist",
     "lint": "tslint ./source/*.ts",
     "prepare-development": "typings install"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "compilerOptions": {
         "target": "es5",
-        "sourceMap": true
+        "sourceMap": true,
+        "declaration": true
     },
     "compileOnSave": false,
     "filesGlob": [


### PR DESCRIPTION
This commit causes 'npm run build' to generate and place TypeScript
definition files in the dist directory, thus enabling users who install
this package to gain access to the typings for each class.
